### PR TITLE
Fix Nodes 2.0 workspace freeze, sticky dragging, and V1 compatibility

### DIFF
--- a/web/adapter-detector.js
+++ b/web/adapter-detector.js
@@ -3,7 +3,7 @@
  * Defaults to V1 immediately, switches to V2 if detected
  */
 
-const BLOCKSPACE_VERSION = "1.0.9";
+const BLOCKSPACE_VERSION = "1.1.0";
 const cacheBuster = `?v=${BLOCKSPACE_VERSION}`;
 
 // Detection state

--- a/web/adapter-detector.js
+++ b/web/adapter-detector.js
@@ -3,7 +3,7 @@
  * Defaults to V1 immediately, switches to V2 if detected
  */
 
-const BLOCKSPACE_VERSION = "1.0.8";
+const BLOCKSPACE_VERSION = "1.0.9";
 const cacheBuster = `?v=${BLOCKSPACE_VERSION}`;
 
 // Detection state

--- a/web/adapter-detector.js
+++ b/web/adapter-detector.js
@@ -3,7 +3,7 @@
  * Defaults to V1 immediately, switches to V2 if detected
  */
 
-const BLOCKSPACE_VERSION = "1.1.1";
+const BLOCKSPACE_VERSION = "1.1.2";
 const cacheBuster = `?v=${BLOCKSPACE_VERSION}`;
 
 // Detection state
@@ -17,7 +17,7 @@ let v2Detected = false;
 function checkV2DOMNodes() {
   if (typeof window === 'undefined') return false;
   return document.querySelector('[data-node-id]') !== null || 
-         !!(window.app?.positionConversion || window.comfyAPI || window.__COMFYUI_FRONTEND_VERSION__);
+         !!(window.app?.positionConversion);
 }
 
 /**

--- a/web/adapter-detector.js
+++ b/web/adapter-detector.js
@@ -3,25 +3,28 @@
  * Defaults to V1 immediately, switches to V2 if detected
  */
 
-const BLOCKSPACE_VERSION = "1.0.5";
+const BLOCKSPACE_VERSION = "1.0.6";
+const cacheBuster = `?v=${BLOCKSPACE_VERSION}`;
 
 // Detection state
 let currentAdapter = 'v1';
 let v2Detected = false;
 
 /**
- * Check for V2 DOM nodes (data-node-id attribute)
- * This is the definitive V2 marker
+ * Check for V2 DOM nodes (data-node-id attribute) or V2 global structures.
+ * This is 100% robust and works even on empty graphs.
  */
 function checkV2DOMNodes() {
-  return document.querySelector('[data-node-id]') !== null;
+  if (typeof window === 'undefined') return false;
+  return document.querySelector('[data-node-id]') !== null || 
+         !!(window.app?.positionConversion || window.comfyAPI || window.__COMFYUI_FRONTEND_VERSION__);
 }
 
 /**
  * Load V1 adapter immediately (default)
  */
 function loadV1Adapter() {
-  import('./adapter-v1.js')
+  import(`./adapter-v1.js${cacheBuster}`)
     .then(({ initV1Adapter }) => {
       initV1Adapter();
       console.log('[BlockSpace] V1 adapter loaded (default)');
@@ -42,7 +45,7 @@ function switchToV2Adapter() {
   console.log('[BlockSpace] V2 detected, switching adapter...');
   
   // 1. Clean up V1 first
-  import('./adapter-v1.js')
+  import(`./adapter-v1.js${cacheBuster}`)
     .then(({ cleanupV1Adapter }) => {
       try {
         cleanupV1Adapter();
@@ -52,7 +55,7 @@ function switchToV2Adapter() {
       }
       
       // 2. Load and initialize V2
-      return import('./adapter-v2.js');
+      return import(`./adapter-v2.js${cacheBuster}`);
     })
     .then(({ initV2Adapter }) => {
       initV2Adapter();
@@ -110,7 +113,7 @@ function forceLoadAdapter(version) {
     console.log('[BlockSpace] Forcing V1 adapter reload...');
     
     // Clean up V2
-    import('./adapter-v2.js')
+    import(`./adapter-v2.js${cacheBuster}`)
       .then(({ cleanupV2Adapter }) => {
         try {
           cleanupV2Adapter();
@@ -120,7 +123,7 @@ function forceLoadAdapter(version) {
         }
         
         // Load and initialize V1
-        return import('./adapter-v1.js');
+        return import(`./adapter-v1.js${cacheBuster}`);
       })
       .then(({ initV1Adapter }) => {
         initV1Adapter();

--- a/web/adapter-detector.js
+++ b/web/adapter-detector.js
@@ -3,7 +3,7 @@
  * Defaults to V1 immediately, switches to V2 if detected
  */
 
-const BLOCKSPACE_VERSION = "1.0.6";
+const BLOCKSPACE_VERSION = "1.0.7";
 const cacheBuster = `?v=${BLOCKSPACE_VERSION}`;
 
 // Detection state

--- a/web/adapter-detector.js
+++ b/web/adapter-detector.js
@@ -3,7 +3,7 @@
  * Defaults to V1 immediately, switches to V2 if detected
  */
 
-const BLOCKSPACE_VERSION = "1.1.0";
+const BLOCKSPACE_VERSION = "1.1.1";
 const cacheBuster = `?v=${BLOCKSPACE_VERSION}`;
 
 // Detection state

--- a/web/adapter-detector.js
+++ b/web/adapter-detector.js
@@ -3,7 +3,7 @@
  * Defaults to V1 immediately, switches to V2 if detected
  */
 
-const BLOCKSPACE_VERSION = "1.0.7";
+const BLOCKSPACE_VERSION = "1.0.8";
 const cacheBuster = `?v=${BLOCKSPACE_VERSION}`;
 
 // Detection state

--- a/web/adapter-v2.js
+++ b/web/adapter-v2.js
@@ -583,6 +583,37 @@ export function initV2Adapter() {
   // Pointer event handlers with capture-phase document listeners
   // This safely captures pointer clicks before Vue components stopPropagation
   const handlePointerdown = (event) => {
+    // Prevent dragging when interacting with custom draggable or interactive embedded widgets in Nodes 2.0
+    const target = event.target;
+    if (target) {
+      const isInput = target.tagName === "INPUT" || 
+                      target.tagName === "TEXTAREA" || 
+                      target.tagName === "SELECT" || 
+                      target.tagName === "BUTTON" || 
+                      target.tagName === "CANVAS";
+
+      const isWidgetElement = target.closest(".comfy-node-widgets") || 
+                              target.closest(".node-widgets") || 
+                              target.closest("[data-widget-name]") ||
+                              target.classList.contains("comfy-widget") ||
+                              target.closest(".comfy-widget") ||
+                              target.closest(".lg-widget") ||
+                              target.closest(".custom-widget");
+
+      const style = window.getComputedStyle(target);
+      const isInteractiveCursor = style.cursor === "pointer" || 
+                                  style.cursor === "ew-resize" || 
+                                  style.cursor === "ns-resize" || 
+                                  style.cursor === "move" || 
+                                  style.cursor === "grab" || 
+                                  style.cursor === "grabbing";
+
+      if (isInput || isWidgetElement || isInteractiveCursor) {
+        event.stopPropagation();
+        return;
+      }
+    }
+
     const focusEnabled = getFocusSettings().enabled;
     const snapEnabled = isSnappingEnabled();
     if (!focusEnabled && !snapEnabled) return;
@@ -888,9 +919,8 @@ function getActiveDraggedNode(canvas, event) {
   if (!canvas) return null;
   if (canvas.dragging_canvas || canvas.resizing_node || canvas.selected_group_resizing) return null;
   if (canvas.node_dragged && canvas.node_dragged.pos && canvas.node_dragged.size) return canvas.node_dragged;
-  if (isLeftMouseDown(event) && canvas.last_mouse_dragging && canvas.current_node && canvas.current_node.pos && canvas.current_node.size && !canvas.connecting_node) {
-    return canvas.current_node;
-  }
+  // Fallback is disabled in V2 to prevent the connection-dragging node-jumping bug.
+  // V2 node dragging snapping is handled natively by handlePointermove.
   return null;
 }
 

--- a/web/adapter-v2.js
+++ b/web/adapter-v2.js
@@ -717,6 +717,23 @@ export function initV2Adapter() {
     const snapEnabled = isSnappingEnabled();
     if (!focusEnabled && !snapEnabled) return;
     if (event.shiftKey) return;
+
+    // Safety check 1: If left mouse button is not pressed, we cannot be dragging/holding a node
+    if (!isLeftMouseDown(event)) {
+      if (focusState.isHolding) {
+        clearFocusState();
+      }
+      return;
+    }
+
+    // Safety check 2: If a connection/wire drag is active, do not snap or drag nodes
+    const canvas = focusState.activeCanvas || getLGraphCanvas();
+    if (canvas?.connecting_node || canvas?.connecting_link) {
+      if (focusState.isHolding) {
+        clearFocusState();
+      }
+      return;
+    }
     
     if (focusState.isHolding && focusState.activeCanvas && focusState.activeNodeId != null) {
       const canvas = focusState.activeCanvas;

--- a/web/adapter-v2.js
+++ b/web/adapter-v2.js
@@ -583,9 +583,22 @@ export function initV2Adapter() {
   // Pointer event handlers with capture-phase document listeners
   // This safely captures pointer clicks before Vue components stopPropagation
   const handlePointerdown = (event) => {
-    // Prevent dragging when interacting with custom draggable or interactive embedded widgets in Nodes 2.0
     const target = event.target;
     if (target) {
+      // 1. Exclude ports/sockets so we don't snap/move nodes while dragging connections in Nodes 2.0
+      const isPort = target.closest(".lg-port") || 
+                     target.closest(".comfy-port") || 
+                     target.closest(".port") || 
+                     target.closest(".socket") || 
+                     target.closest("[data-port-name]") || 
+                     target.closest("[data-port-type]") || 
+                     target.closest("[data-slot]") || 
+                     target.closest(".slot") || 
+                     target.closest(".lg-node-port") || 
+                     target.closest(".lg-node-slot") || 
+                     target.closest(".port-circle");
+
+      // 2. Exclude interactive form inputs and custom widgets
       const isInput = target.tagName === "INPUT" || 
                       target.tagName === "TEXTAREA" || 
                       target.tagName === "SELECT" || 
@@ -600,9 +613,11 @@ export function initV2Adapter() {
                               target.closest(".lg-widget") ||
                               target.closest(".custom-widget");
 
-      if (isInput || isWidgetElement) {
-        event.stopPropagation();
-        return;
+      if (isPort || isInput || isWidgetElement) {
+        if (isInput || isWidgetElement) {
+          event.stopPropagation();
+        }
+        return; // Exit early: do not initiate node snapping/dragging
       }
     }
 

--- a/web/adapter-v2.js
+++ b/web/adapter-v2.js
@@ -596,14 +596,26 @@ export function initV2Adapter() {
                      target.closest(".slot") || 
                      target.closest(".lg-node-port") || 
                      target.closest(".lg-node-slot") || 
-                     target.closest(".port-circle");
+                     target.closest(".port-circle") ||
+                     target.closest(".lg-port-input") ||
+                     target.closest(".lg-port-output") ||
+                     target.closest(".lg-node-input") ||
+                     target.closest(".lg-node-output") ||
+                     target.closest(".input-port") ||
+                     target.closest(".output-port") ||
+                     target.closest(".comfy-node-input") ||
+                     target.closest(".comfy-node-output") ||
+                     target.closest(".lg-socket") ||
+                     target.closest(".socket-input") ||
+                     target.closest(".socket-output");
 
-      // 2. Exclude interactive form inputs and custom widgets
+      // 2. Exclude interactive form inputs and custom widgets (but NOT the main graph canvas!)
+      const mainCanvasEl = getLGraphCanvas()?.canvas;
       const isInput = target.tagName === "INPUT" || 
                       target.tagName === "TEXTAREA" || 
                       target.tagName === "SELECT" || 
                       target.tagName === "BUTTON" || 
-                      target.tagName === "CANVAS";
+                      (target.tagName === "CANVAS" && target !== mainCanvasEl);
 
       const isWidgetElement = target.closest(".comfy-node-widgets") || 
                               target.closest(".node-widgets") || 
@@ -611,7 +623,13 @@ export function initV2Adapter() {
                               target.classList.contains("comfy-widget") ||
                               target.closest(".comfy-widget") ||
                               target.closest(".lg-widget") ||
-                              target.closest(".custom-widget");
+                              target.closest(".custom-widget") ||
+                              target.closest(".comfy-node-widget") ||
+                              target.closest(".node-widget") ||
+                              target.closest(".comfy-input") ||
+                              target.closest(".lg-node-widget") ||
+                              target.closest(".widget") ||
+                              target.closest("[data-widget-type]");
 
       if (isPort || isInput || isWidgetElement) {
         if (isInput || isWidgetElement) {

--- a/web/adapter-v2.js
+++ b/web/adapter-v2.js
@@ -600,15 +600,7 @@ export function initV2Adapter() {
                               target.closest(".lg-widget") ||
                               target.closest(".custom-widget");
 
-      const style = window.getComputedStyle(target);
-      const isInteractiveCursor = style.cursor === "pointer" || 
-                                  style.cursor === "ew-resize" || 
-                                  style.cursor === "ns-resize" || 
-                                  style.cursor === "move" || 
-                                  style.cursor === "grab" || 
-                                  style.cursor === "grabbing";
-
-      if (isInput || isWidgetElement || isInteractiveCursor) {
+      if (isInput || isWidgetElement) {
         event.stopPropagation();
         return;
       }


### PR DESCRIPTION
This Pull Request resolves critical interaction conflicts in Nodes 2.0 (Modern UI) and restores compatibility with the legacy V1 Canvas UI.

### Key Changes
1. **Nodes 2.0 Canvas Freeze Fix**: Exempted the main graph canvas background from being treated as an interactive widget canvas. This prevents event.stopPropagation() on background clicks/drags, ensuring panning, zooming, and connection-finalization propagate correctly and completely resolving workspace freezes.
2. **Persistent Sticky Dragging Fix**: Implemented self-healing button-state and active connection safeguards in handlePointermove. If a user moves their mouse without holding the left mouse button, or is dragging a connection wire, any stuck node-dragging state is instantly reset, preventing nodes from sticking to the cursor.
3. **Restored V1 Snapping Compatibility**: Refined the V2 environment detector in \dapter-detector.js\ to look only for V2-specific structures (\window.app.positionConversion\), ignoring global version and API flags present in legacy ComfyUI V1. This prevents false positives and restores full snapping and guidelines in legacy ComfyUI V1.
4. **Expanded CSS Selectors**: Expanded the port/socket and custom widget element selector lists to be fully comprehensive across standard and custom node types.